### PR TITLE
Fixed double quote containing cell encoding

### DIFF
--- a/lib/csv/encode.ex
+++ b/lib/csv/encode.ex
@@ -38,7 +38,8 @@ defimpl CSV.Encode, for: BitString do
         << separator :: utf8 >>,
         delimiter,
         << @carriage_return :: utf8 >>,
-        << @newline :: utf8 >>
+        << @newline :: utf8 >>,
+        << @double_quote :: utf8 >>
       ]) ->
         << @double_quote :: utf8 >> <>
       (data |> escape |> String.replace(


### PR DESCRIPTION
Fixed encoding of cells containing double quote characters. Previously, cells containing a double quote were not escaped.

For example, previously

> [["a", "Sub 4\" Paving", "b"]]

was encoded as

> a,Sub 4" Paving,b

which is not correct. This change fixes it so that it is encoded as:

> a,"Sub 4"" Paving",b